### PR TITLE
Potential fix for code scanning alert no. 42: Resolving XML external entity in user-controlled data

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/xxe/BlindSendFileAssignment.java
+++ b/src/main/java/org/owasp/webgoat/lessons/xxe/BlindSendFileAssignment.java
@@ -76,7 +76,7 @@ public class BlindSendFileAssignment implements AssignmentEndpoint, Initializabl
     }
 
     try {
-      Comment comment = comments.parseXml(commentStr, false);
+      Comment comment = comments.parseXml(commentStr);
       if (fileContentsForUser.contains(comment.getText())) {
         comment.setText("Nice try, you need to send the file to WebWolf");
       }

--- a/src/main/java/org/owasp/webgoat/lessons/xxe/CommentsCache.java
+++ b/src/main/java/org/owasp/webgoat/lessons/xxe/CommentsCache.java
@@ -65,16 +65,13 @@ public class CommentsCache {
    * progress etc). In real life the XmlMapper bean defined above will be used automatically and the
    * Comment class can be directly used in the controller method (instead of a String)
    */
-  protected Comment parseXml(String xml, boolean securityEnabled)
-      throws XMLStreamException, JAXBException {
+  protected Comment parseXml(String xml) throws XMLStreamException, JAXBException {
     var jc = JAXBContext.newInstance(Comment.class);
     var xif = XMLInputFactory.newInstance();
 
-    // TODO fix me disabled for now.
-    if (securityEnabled) {
-      xif.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, ""); // Compliant
-      xif.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, ""); // compliant
-    }
+    // Securely configure XMLInputFactory to prevent XXE attacks
+    xif.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, ""); // Disallow DTDs
+    xif.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, ""); // Disallow external schemas
 
     var xsr = xif.createXMLStreamReader(new StringReader(xml));
 


### PR DESCRIPTION
Potential fix for [https://github.com/leountio/WebGoat/security/code-scanning/42](https://github.com/leountio/WebGoat/security/code-scanning/42)

To fix the issue, the XML parser must be securely configured to prevent external entity expansion regardless of the `securityEnabled` flag. This involves:
1. Disabling external DTDs and schemas unconditionally.
2. Ensuring that the `XMLInputFactory` is always configured securely before parsing user-controlled input.

The changes will be made in the `parseXml` method of `CommentsCache`. Specifically:
- The `securityEnabled` flag will be removed, and secure configurations will be applied unconditionally.
- The `XMLInputFactory` will be configured to disallow external DTDs and schemas.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
